### PR TITLE
move from CGILib7 to CGILib8

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@
 CC      = gcc -std=c99 -pedantic -Wall -Wextra -Wwrite-strings
 CFLAGS  = -g
 LDFLAGS = -g
-LDLIBS  = -lcgi7 -lmc6809 -lm
+LDLIBS  = -lcgi8 -lmc6809 -lm
 
 .PHONY: clean
 

--- a/a09.h
+++ b/a09.h
@@ -40,7 +40,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#include <cgilib7/tree.h>
+#include <cgilib8/tree.h>
 
 enum
 {


### PR DESCRIPTION
Hi Sean,

I had some trouble building a09 (it seems to be missing the latest CGILib8 include files and link libs so I went ahead and fixed it up. I'm sending a PR in case it is useful/helps.

My notes to do the full build is listed below (again, just in case it helps anyone else trying to build it).

Charles

}------------------------------------------------------------------------------{
github.com/spc476/CGILib # CGI stuff - used by 6809 assembler a09 below
make prefix=$(realpath ../build)
make prefix=$(realpath ../build) install
}------------------------------------------------------------------------------{
github.com/spc476/mc6809 # 6809 emulator in C - used by 6809 assembler a09 below
make prefix=$(realpath ../build)
make prefix=$(realpath ../build) install
}------------------------------------------------------------------------------{
github.com/spc476/a09 # 6809 assembler a09 - uses stuff listed above
# Needed to make some changes to move from CGILib7 to CGILib8 : see git diff
make CFLAGS=-I../build/include LDFLAGS=-L../build/lib
}------------------------------------------------------------------------------{